### PR TITLE
K8s: Add VolumeMount for Temp Folder

### DIFF
--- a/deployment/k8s/install-full.yaml
+++ b/deployment/k8s/install-full.yaml
@@ -117,7 +117,7 @@ spec:
         - name: raylevation-srtm
           emptyDir: {}
         - name: raylevation-tmp
-          emptyDir: { }
+          emptyDir: {}
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/deployment/k8s/install-full.yaml
+++ b/deployment/k8s/install-full.yaml
@@ -58,6 +58,8 @@ spec:
               name: raylevation-pvc
             - mountPath: /srtm/
               name: raylevation-srtm
+            - mountPath: /tmp/
+              name: raylevation-tmp
       containers:
         - name: raylevation-server
           image: ghcr.io/raynigon/raylevation:v0.0.1
@@ -86,6 +88,8 @@ spec:
           volumeMounts:
             - mountPath: /data/
               name: raylevation-pvc
+            - mountPath: /tmp/
+              name: raylevation-tmp
           readinessProbe:
             httpGet:
               path: /actuator/healthcheck
@@ -112,6 +116,8 @@ spec:
             claimName: raylevation-pvc
         - name: raylevation-srtm
           emptyDir: {}
+        - name: raylevation-tmp
+          emptyDir: { }
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/deployment/k8s/install-minimum.yaml
+++ b/deployment/k8s/install-minimum.yaml
@@ -117,7 +117,7 @@ spec:
         - name: raylevation-srtm
           emptyDir: {}
         - name: raylevation-tmp
-          emptyDir: { }
+          emptyDir: {}
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/deployment/k8s/install-minimum.yaml
+++ b/deployment/k8s/install-minimum.yaml
@@ -30,7 +30,7 @@ spec:
     spec:
       initContainers:
         - name: raylevation-download
-          image: ghcr.io/raynigon/raylevation:v0.0.2
+          image: ghcr.io/raynigon/raylevation:v0.0.1
           imagePullPolicy: Always
           env:
             - name: RAYLEVATION_CLI_CMD
@@ -58,9 +58,11 @@ spec:
               name: raylevation-pvc
             - mountPath: /srtm/
               name: raylevation-srtm
+            - mountPath: /tmp/
+              name: raylevation-tmp
       containers:
         - name: raylevation-server
-          image: ghcr.io/raynigon/raylevation:v0.0.2
+          image: ghcr.io/raynigon/raylevation:v0.0.1
           imagePullPolicy: Always
           ports:
             - containerPort: 8080
@@ -86,6 +88,8 @@ spec:
           volumeMounts:
             - mountPath: /data/
               name: raylevation-pvc
+            - mountPath: /tmp/
+              name: raylevation-tmp
           readinessProbe:
             httpGet:
               path: /actuator/healthcheck
@@ -112,6 +116,8 @@ spec:
             claimName: raylevation-pvc
         - name: raylevation-srtm
           emptyDir: {}
+        - name: raylevation-tmp
+          emptyDir: { }
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
The Pod needs to write into `/tmp`, but since the root file system is read only, this does not work.
We need to mount an `emptyDir` volume in every pod at `/tmp`.